### PR TITLE
fixes for demos and tests to use with go1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-include $(GOROOT)/src/Make.inc
-
-TARG=stats
-GOFILES=\
-	stats.go\
-	regression.go
-
-include $(GOROOT)/src/Make.pkg

--- a/demos/descriptive_statistics/Makefile
+++ b/demos/descriptive_statistics/Makefile
@@ -1,7 +1,0 @@
-include $(GOROOT)/src/Make.inc
-
-TARG=descriptive_stats_demo
-GOFILES=\
-	descriptive_stats_demo.go\
-
-include $(GOROOT)/src/Make.cmd

--- a/demos/descriptive_statistics/descriptive_stats_demo.go
+++ b/demos/descriptive_statistics/descriptive_stats_demo.go
@@ -12,9 +12,9 @@
 package main
 
 import (
-	"stats" // assumes you've done 'make install' in the stats directory
 	"fmt"
-	"rand"
+	"math/rand"
+	stats "../../"
 	"time"
 )
 
@@ -124,7 +124,7 @@ func normalDistributionDemo() {
 func main() {
 	fmt.Printf("GoStats Demo\n\n")
 
-	rand.Seed(time.Nanoseconds())
+	rand.Seed(time.Now().Unix())
 
 	incrementalDemo()
 	batchDemo()

--- a/demos/regression/Makefile
+++ b/demos/regression/Makefile
@@ -1,7 +1,0 @@
-include $(GOROOT)/src/Make.inc
-
-TARG=regression_demo
-GOFILES=\
-	regression_demo.go\
-
-include $(GOROOT)/src/Make.cmd

--- a/demos/regression/regression_demo.go
+++ b/demos/regression/regression_demo.go
@@ -11,14 +11,13 @@
 package main
 
 import (
-	"stats" // assumes you've done 'make install' in the stats directory
 	"fmt"
-	"rand"
+	"math/rand"
+	stats "../../"
 	"time"
 )
 
 const NUM_SAMPLES = 5
-
 
 func incrementalRegressionDemo() {
 	var r stats.Regression
@@ -67,7 +66,7 @@ func batchRegressionDemo() {
 	fmt.Printf("** array of values:\n")
 	xData := make([]float64, NUM_SAMPLES)
 	for i := 0; i < NUM_SAMPLES; i++ {
-		xData[i] = float64(i)*3.0
+		xData[i] = float64(i) * 3.0
 	}
 	printArray("xData", xData)
 	yData := makeArray(NUM_SAMPLES, 100, -25)
@@ -84,11 +83,10 @@ func batchRegressionDemo() {
 	fmt.Printf("intercept standard error = %v\n", intcptStdErr)
 }
 
-
 func main() {
 	fmt.Printf("GoStats Demo\n\n")
 
-	rand.Seed(time.Nanoseconds())
+	rand.Seed(time.Now().Unix())
 
 	incrementalRegressionDemo()
 	batchRegressionDemo()

--- a/stats_test.go
+++ b/stats_test.go
@@ -38,14 +38,13 @@ package stats
 //
 
 import (
-	"testing"
 	"math"
-	"rand"
+	"math/rand"
+	"testing"
 	"time"
 )
 
 const TOL = 1e-14
-
 
 //
 //
@@ -251,7 +250,6 @@ func TestArrayStats(t *testing.T) {
 	checkFloat64(StatsSampleKurtosis(a), -1.2, TOL, "SampleKurtosis", t)
 }
 
-
 func TestArrayStats2(t *testing.T) {
 	a := []float64{1.0, -2.0, 13.0, 47.0, 115.0, -0.03, -123.4, 23.0, -23.04, 12.3}
 	checkInt(StatsCount(a), 10, "Count", t)
@@ -343,7 +341,7 @@ func BenchmarkCalcSampleKurtosis10(b *testing.B) {
 // resulting stable time is the time for the calculation on 100k values.
 func BenchmarkCalcSampleKurtosis100k(b *testing.B) {
 	b.StopTimer()
-	rand.Seed(time.Nanoseconds())
+	rand.Seed(time.Now().Unix())
 	n := 100000 // not the same as b.N
 	a := make([]float64, n)
 	for i := 0; i < n; i++ {
@@ -486,10 +484,6 @@ func TestUpdate010(t *testing.T) {
 	checkNaN(d.SampleKurtosis(), "SampleKurtosis", t)
 }
 
-
-
-
-
 //
 //
 // Assertion functions used for tests
@@ -504,7 +498,7 @@ func checkInt(x, y int, test string, t *testing.T) {
 }
 
 func checkFloat64(x, y, tol float64, test string, t *testing.T) {
-	if math.Fabs(x-y) > math.Fabs(x*tol) {
+	if math.Abs(x-y) > math.Abs(x*tol) {
 		t.Errorf("Found %v, but expected %v for test %v", x, y, test)
 	}
 }
@@ -516,7 +510,7 @@ func checkNaN(x float64, test string, t *testing.T) {
 }
 
 func checkFloat64Abs(x, y, tol float64, test string, t *testing.T) {
-	if math.Fabs(x-y) > math.Fabs(tol) {
+	if math.Abs(x-y) > math.Abs(tol) {
 		t.Errorf("Found %v, but expected %v for test %v", x, y, test)
 	}
 }


### PR DESCRIPTION
quick list of changes
- Makefiles aren't necessary anymore
- `go fix` and call `time.Now().Unix()` for seeding in demos and tests
- relative import in demos of stats package
